### PR TITLE
Assume 0 dupes for cycles prior QoL MK2

### DIFF
--- a/public/scripts/parseSaves.js
+++ b/public/scripts/parseSaves.js
@@ -27,7 +27,10 @@ exports.parseToCSV = function(saveFile, _callback) {
 
     allReports.templateData.dailyReports.forEach(reportDay => {
         //Find the number of dupes for each day by pulling the child entries from the Stress Change report.
-        const numDupes = reportDay.reportEntries[2].contextEntries.elements.filter(x => x !== null).length;
+        var numDupes = 0;
+        if(reportDay.reportEntries[2].contextEntries.elements !== null) {
+            numDupes = reportDay.reportEntries[2].contextEntries.elements.filter(x => x !== null).length;
+        }
         
         saveWriter.write(reportDay.day + ", " + numDupes + ", ");
         


### PR DESCRIPTION
The method for geting number of dupes doesn't work properly for reports from
cycles preceding QoL MK2 update and OSR crashes on null. This workaround just
assumes 0 dupes in those cases.