### PR TITLE
Use writable.end instead of close to properly close stream

### DIFF
--- a/public/scripts/parseSaves.js
+++ b/public/scripts/parseSaves.js
@@ -86,7 +86,7 @@ exports.parseToCSV = function(saveFile, _callback) {
         saveWriter.write('\n');
     });
 
-    saveWriter.close();
+    saveWriter.end();
 
     //Wait for the file to completely finish parsing before sending the callback.
     saveWriter.on('finish', function () {
@@ -136,7 +136,7 @@ exports.parseToText = function (saveFile, _callback) {
         })
     });
 
-    saveWriter.close();
+    saveWriter.end();
 
     //Wait for the file to completely finish parsing before sending the callback.
     saveWriter.on('finish', function () {

--- a/public/scripts/parseSaves.js
+++ b/public/scripts/parseSaves.js
@@ -86,11 +86,8 @@ exports.parseToCSV = function(saveFile, _callback) {
         saveWriter.write('\n');
     });
 
-    saveWriter.end();
-
-    //Wait for the file to completely finish parsing before sending the callback.
-    saveWriter.on('finish', function () {
-        console.log('File Parse Completed');
+    saveWriter.end(function() {
+        console.log('File Write Completed');
         _callback();
     });
 }
@@ -136,11 +133,8 @@ exports.parseToText = function (saveFile, _callback) {
         })
     });
 
-    saveWriter.end();
-
-    //Wait for the file to completely finish parsing before sending the callback.
-    saveWriter.on('finish', function () {
-        console.log('File Save Completed');
+    saveWriter.end(function() {
+        console.log('File Write Completed');
         _callback();
     });
 } 


### PR DESCRIPTION
the close() method closed the stream without actually waiting for the write to finish

https://nodejs.org/api/stream.html#stream_writable_end_chunk_encoding_callback